### PR TITLE
Add aptabase analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chat-bar-site",
       "version": "0.1.0",
       "dependencies": {
+        "@aptabase/react": "^0.3.3",
         "lucide-react": "^0.289.0",
         "next": "13.5.6",
         "react": "^18",
@@ -45,6 +46,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aptabase/react": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@aptabase/react/-/react-0.3.3.tgz",
+      "integrity": "sha512-/8pSVMv5kElaVD4ukDQmPzF7sw/VsOM/P/B/4tieUZt3zmACPcVpYTFQZ0oYESSn/yTvVIU1iTeXa6zKwxi4vw==",
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@aptabase/react": "^0.3.3",
     "lucide-react": "^0.289.0",
     "next": "13.5.6",
     "react": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import { AptabaseProvider } from '@aptabase/react';
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -38,9 +39,12 @@ export default function RootLayout({
       <body
         className={`${inter.className} bg-slate-900 text-slate-300 text-lg min-h-screen overflow-x-hidden`}
       >
-        <Navbar />
-        {children}
-        <Footer />
+        <AptabaseProvider appKey="A-US-4948848664">
+          <Navbar />
+          {children}
+          <Footer />
+        </AptabaseProvider>
+
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,10 +11,12 @@ import Windows from "@/components/icons/Windows";
 import Linux from "@/components/icons/Linux";
 import Apple from "super-tiny-icons/images/svg/apple.svg";
 import IconLink from "@/components/IconLink";
+import Analytics from "@/components/Analytics";
 
 export default function Home() {
   return (
     <main className="pt-24 lg:pt-28 antialiased">
+      <Analytics name="page.home" />
       <div className="relative container lg:w-4/5">
         {/* <Image
           src="/bg.png"

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -13,7 +13,7 @@ export default function Analytics(props: Props) {
   useEffect(() => {
     console.debug('tracking event:', props.name);
     trackEvent(props.name, props.attrs);
-  }, []); // Empty dependency array ensures this effect runs only once on mount
+  });
 
   return null; // Since this component does not render anything, return null
 }

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useAptabase } from "@aptabase/react";
+import { useEffect } from "react";
+
+export type Props = {
+  name: string
+  attrs?: Record<string, string | number | boolean>
+}
+
+export default function Analytics(props: Props) {
+  const { trackEvent } = useAptabase();
+  useEffect(() => {
+    console.debug('tracking event:', props.name);
+    trackEvent(props.name, props.attrs);
+  }, []); // Empty dependency array ensures this effect runs only once on mount
+
+  return null; // Since this component does not render anything, return null
+}


### PR DESCRIPTION
I have evaluated many web analytics SaaS options, including
- [Umami](https://umami.is)
- [Fathom](https://github.com/usefathom/fathom)
- [Plausible](https://plausible.io)

Finally decided to use aptabase, since it has free allowance 20k events per month, and support electron app as well.

[Link to the analytics dashboard](https://us.aptabase.com/BH9OQuW9T8FQjaYKPfyKYy/)